### PR TITLE
 Add minimum versions for `urllib3` and `requests`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /src/readthedocs_cli.egg-info/
+__pycache__/
+/.venv/

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,10 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     click >=8
-    requests
+    requests >=2.30.0
     rich
     pyyaml
+    urllib3 >=2.0.0
 
 [options.extras_require]
 maintainers-sync =


### PR DESCRIPTION
## Description of proposed changes

It's not entirely clear _why_ this works, but using urllib3>=2.0.0 avoids the 403 Client error.¹

Adding minimum version for `requests` the first version that officially supports urllib3 v2.²

¹ <https://github.com/nextstrain/readthedocs-cli/issues/7#issuecomment-2515859426>
² <https://github.com/psf/requests/releases/tag/v2.30.0>

## Related issue(s)

Resolves #7 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
